### PR TITLE
Update vector.py : improve calculation for parallels vectors (straight limbs)

### DIFF
--- a/release/scripts/mgear/core/vector.py
+++ b/release/scripts/mgear/core/vector.py
@@ -81,8 +81,12 @@ def getPlaneNormal(v0, v1, v2):
     vector0.normalize()
     vector1.normalize()
 
-    normal = vector1 ^ vector0
-    normal.normalize()
+    if vector0.isParallel(vector1):
+        # if vectors are parallel, we use an arbitrary up vector to resolve the plane. 
+        # TODO: add an optional parameter to this function so joints will be aligned from the given guide axis instead of arbitrary vector.
+        normal = vector0 ^ datatypes.Vector(0, 0, -1)
+    else:
+        normal = vector1 ^ vector0    normal.normalize()
 
     return normal
 


### PR DESCRIPTION
This fix helps the guide building correct joint axis when the given points are collinears (and so the two resulting vectors for plane normal solving are parallels).  Next step for more precision : we could add an extra parameter to this function where we give up axis of the guide, so up axis of the guide will be the same as up axis of the chain, and only when vectors are parallels.

## Description of Changes

At least, when vectors are parallels, all the orientation are aiming to the end of the chain. The up vector could be more precise or defined by an extra parameter, but the chain isn't broken with this fix.
It improves controls and joints orientations. 

## Testing Done

I did it on Maya 2023, mgear 5.0.7, with EPIC Arm guides in many positions.

